### PR TITLE
reintroduce readr import for read_file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,7 @@ Imports:
     fs,
     glue,
     purrr,
+    readr,
     rlang,
     stringr,
     tarchetypes,

--- a/R/source_sql_to_dataframe.R
+++ b/R/source_sql_to_dataframe.R
@@ -1,16 +1,13 @@
 source_sql_to_dataframe <- function(path, query_params = NULL) {
 
-  lines <- readLines(path)
-  connection_string <- stringr::str_extract(lines[1], "(?<=\\=).*")
+  connection_string <- stringr::str_extract(readr::read_lines(path, n_max = 1), "(?<=\\=).*")
   connection_call <- paste0("con <- ", connection_string)
   eval(parse(text = connection_call))
   on.exit(DBI::dbDisconnect(con))
   delimiters <- strsplit(sqltargets_option_get("sqltargets.glue_sql_delimiters"), "")[[1]]
   open <- delimiters[1]
   close <- delimiters[2]
-  query <- lines[2:length(lines)]
-  query <- query[!grepl("tar_load", query)]
-  query <- paste(query, collapse = " ")
+  query <- readr::read_file(path)
   query <- glue::glue_sql(query, .con = con, .open = open, .close = close, .envir = query_params)
   out <- DBI::dbGetQuery(con, query)
   msg <- glue::glue("{basename(path)} executed:\n Rows: {nrow(out)}\n Columns: {ncol(out)}")


### PR DESCRIPTION
Per #11, some heavily commented queries weren't being recognized after the string manipulation in `source_sql_to_dataframe()`. This PR reintroduces the readr import for `readr::read_file()` which correctly handles comments, encoding, etc.