### PR TITLE
Implement Jinja functionality

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,7 @@ Imports:
     DBI,
     fs,
     glue,
+    jinjar,
     purrr,
     readr,
     rlang,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# sqltargets (dev)
+
+* Included 'jinjar' as a dependency, allowing jinja-like SQL queries
+* Breaking change: `query_params` argument in `tar_sql()` is now `params`.
+* Additional tests
+
 # sqltargets 0.1.0
 
 * Added two additional options for the opening and closing delimiters.

--- a/R/source_sql_to_dataframe.R
+++ b/R/source_sql_to_dataframe.R
@@ -1,22 +1,24 @@
-source_sql_to_dataframe <- function(path, params) {
+source_sql_to_dataframe <- function(path, params = NULL) {
 
   connection_string <- stringr::str_extract(readr::read_lines(path, n_max = 1), "(?<=\\=).*")
   connection_call <- paste0("con <- ", connection_string)
   rlang::eval_bare(rlang::parse_expr(connection_call))
   on.exit(DBI::dbDisconnect(con))
   query <- readr::read_file(path)
-  query <- jinjar::render(
-    query,
-    params = params,
-    .config = jinjar::jinjar_config(
-      block_open = sqltargets_option_get("sqltargets.jinja_block_open"),
-      block_close = sqltargets_option_get("sqltargets.jinja_block_close"),
-      variable_open = sqltargets_option_get("sqltargets.jinja_variable_open"),
-      variable_close = sqltargets_option_get("sqltargets.jinja_variable_close"),
-      comment_open = sqltargets_option_get("sqltargets.jinja_comment_open"),
-      comment_close = sqltargets_option_get("sqltargets.jinja_comment_close"),
+  if (!is.null(params)) {
+    query <- jinjar::render(
+      query,
+      params = params,
+      .config = jinjar::jinjar_config(
+        block_open = sqltargets_option_get("sqltargets.jinja_block_open"),
+        block_close = sqltargets_option_get("sqltargets.jinja_block_close"),
+        variable_open = sqltargets_option_get("sqltargets.jinja_variable_open"),
+        variable_close = sqltargets_option_get("sqltargets.jinja_variable_close"),
+        comment_open = sqltargets_option_get("sqltargets.jinja_comment_open"),
+        comment_close = sqltargets_option_get("sqltargets.jinja_comment_close"),
       )
     )
+  }
   out <- DBI::dbGetQuery(con, query)
   msg <- glue::glue("{basename(path)} executed:\n Rows: {nrow(out)}\n Columns: {ncol(out)}")
   cli::cli_alert_success(msg)

--- a/R/source_sql_to_dataframe.R
+++ b/R/source_sql_to_dataframe.R
@@ -1,13 +1,22 @@
-source_sql_to_dataframe <- function(path, query_params = NULL) {
+source_sql_to_dataframe <- function(path, params) {
 
   connection_string <- stringr::str_extract(readr::read_lines(path, n_max = 1), "(?<=\\=).*")
   connection_call <- paste0("con <- ", connection_string)
   rlang::eval_bare(rlang::parse_expr(connection_call))
   on.exit(DBI::dbDisconnect(con))
-  open <- sqltargets_option_get("sqltargets.glue_sql_opening_delimiter")
-  close <- sqltargets_option_get("sqltargets.glue_sql_closing_delimiter")
   query <- readr::read_file(path)
-  query <- glue::glue_sql(query, .con = con, .open = open, .close = close, .envir = query_params)
+  query <- jinjar::render(
+    query,
+    params = params,
+    .config = jinjar::jinjar_config(
+      block_open = sqltargets_option_get("sqltargets.jinja_block_open"),
+      block_close = sqltargets_option_get("sqltargets.jinja_block_close"),
+      variable_open = sqltargets_option_get("sqltargets.jinja_variable_open"),
+      variable_close = sqltargets_option_get("sqltargets.jinja_variable_close"),
+      comment_open = sqltargets_option_get("sqltargets.jinja_comment_open"),
+      comment_close = sqltargets_option_get("sqltargets.jinja_comment_close"),
+      )
+    )
   out <- DBI::dbGetQuery(con, query)
   msg <- glue::glue("{basename(path)} executed:\n Rows: {nrow(out)}\n Columns: {ncol(out)}")
   cli::cli_alert_success(msg)

--- a/R/sqltargets-option.R
+++ b/R/sqltargets-option.R
@@ -9,8 +9,12 @@
 #'
 #' ## Available Options
 #'
-#'  - `"sqltargets.glue_sql_opening_delimiter"` - character. Length 1. Two characters. The opening delimiter passed to `glue::glue_sql()`.
-#'  - `"sqltargets.glue_sql_closing_delimiter"` - character. Length 1. Two characters. The closing delimiter passed to `glue::glue_sql()`.
+#'  - `"sqltargets.jinja_block_open"` - character. Length 1. The opening delimiter passed to `jinjar::jinjar_config()`.
+#'  - `"sqltargets.jinja_block_close"` - character. Length 1. The closing delimiter passed to `jinjar::jinjar_config()`.
+#'  - `"sqltargets.jinja_variable_open"` - character. Length 1. The closing delimiter passed to `jinjar::jinjar_config()`.
+#'  - `"sqltargets.jinja_variable_close"` - character. Length 1. The closing delimiter passed to `jinjar::jinjar_config()`.
+#'  - `"sqltargets.jinja_comment_open"` - character. Length 1. The closing delimiter passed to `jinjar::jinjar_config()`.
+#'  - `"sqltargets.jinja_comment_close"` - character. Length 1. The closing delimiter passed to `jinjar::jinjar_config()`.
 #' @rdname sqltargets-options
 #' @export
 sqltargets_option_get <- function(option_name) {

--- a/R/tar_sql.R
+++ b/R/tar_sql.R
@@ -22,9 +22,9 @@
 #' @return A data frame
 #' @inheritParams targets::tar_target
 #' @inheritParams tar_sql_raw
-#' @param query_params Code, can be `NULL`.
-#'   `query_params` evaluates to a named list of parameters
-#'   that are passed via `glue::glue_sql()`. The list is quoted
+#' @param params Code, can be `NULL`.
+#'   `params` evaluates to a named list of parameters
+#'   that are passed to `jinjar::render()`. The list is quoted
 #'   (not evaluated until the target runs)
 #'   so that upstream targets can serve as parameter values.
 #' @examples
@@ -50,7 +50,7 @@
 #' })
 tar_sql <- function(name,
                     path,
-                    query_params = list(),
+                    params = list(),
                     format = targets::tar_option_get("format"),
                     tidy_eval = targets::tar_option_get("tidy_eval"),
                     repository = targets::tar_option_get("repository"),
@@ -69,8 +69,8 @@ tar_sql <- function(name,
   check_pkg_installed("glue")
 
   name <- targets::tar_deparse_language(substitute(name))
-  query_params <- targets::tar_tidy_eval(
-    expr = substitute(query_params),
+  params <- targets::tar_tidy_eval(
+    expr = substitute(params),
     envir = targets::tar_option_get("envir"),
     tidy_eval = tidy_eval
   )
@@ -78,7 +78,7 @@ tar_sql <- function(name,
   tar_sql_raw(
     name = name,
     path = path,
-    query_params = query_params,
+    params = params,
     format = format,
     error = error,
     memory = memory,

--- a/R/tar_sql_raw.R
+++ b/R/tar_sql_raw.R
@@ -23,7 +23,11 @@
 #' @inheritParams targets::tar_target_raw
 #' @param path Character of length 1 to the single `*.sql` source file to be executed.
 #'   Defaults to the working directory of the `targets` pipeline.
-#' @param query_params A named list of parameters for parameterized queries.
+#' @param params Code, can be `NULL`.
+#'   `params` evaluates to a named list of parameters
+#'   that are passed to `jinjar::render()`. The list is quoted
+#'   (not evaluated until the target runs)
+#'   so that upstream targets can serve as parameter values.
 #' @examples
 #' targets::tar_dir({  # tar_dir() runs code from a temporary directory.
 #'   # Unparameterized SQL query:
@@ -48,7 +52,7 @@
 tar_sql_raw <- function(
     name,
     path = ".",
-    query_params = query_params,
+    params = params,
     format = format,
     error = targets::tar_option_get("error"),
     memory = targets::tar_option_get("memory"),
@@ -64,15 +68,15 @@ tar_sql_raw <- function(
   targets::tar_assert_chr(name)
   targets::tar_assert_nzchar(name)
   targets::tar_assert_file(path)
-  targets::tar_assert_lang(query_params)
-  targets::tar_assert_not_expr(query_params)
+  targets::tar_assert_lang(params)
+  targets::tar_assert_not_expr(params)
 
   file_command <- tar_sql_file_command(path = path)
   file_dep <- basename(path)
 
   query_command <- tar_sql_command(
     path = path,
-    query_params = query_params,
+    params = params,
     file_dep = file_dep
   )
 
@@ -131,17 +135,17 @@ tar_sql_file_command <- function(path) {
 
 tar_sql_command <- function(
     path,
-    query_params,
+    params,
     file_dep
 ) {
   args <- substitute(
     list(
       path = path,
-      query_params = query_params
+      params = params
     ),
     env = list(
       path = path,
-      query_params = query_params
+      params = params
     )
   )
   deps <- c(sort(unique(sql_deps(path))), file_dep)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -5,7 +5,11 @@ sqltargets_env <- function() {
 }
 
 .onAttach <- function(lib, pkg) {
-  sqltargets.env$sqltargets.target_file_suffix <- "_query_file"
-  sqltargets.env$sqltargets.glue_sql_opening_delimiter <- formals(glue::glue)$.open
-  sqltargets.env$sqltargets.glue_sql_closing_delimiter <- formals(glue::glue)$.close
+  jinjar_defaults <- jinjar::default_config()
+  sqltargets.env$sqltargets.jinja_block_open <- jinjar_defaults$block_open
+  sqltargets.env$sqltargets.jinja_block_close <- jinjar_defaults$block_close
+  sqltargets.env$sqltargets.jinja_comment_open <- jinjar_defaults$comment_open
+  sqltargets.env$sqltargets.jinja_comment_close <- jinjar_defaults$comment_close
+  sqltargets.env$sqltargets.jinja_variable_open <- jinjar_defaults$variable_open
+  sqltargets.env$sqltargets.jinja_variable_close <- jinjar_defaults$variable_close
 }

--- a/man/sqltargets-options.Rd
+++ b/man/sqltargets-options.Rd
@@ -23,6 +23,10 @@ Get or Set sqltargets Options
 \details{
 ## Available Options
 
- - `"sqltargets.glue_sql_opening_delimiter"` - character. Length 1. Two characters. The opening delimiter passed to `glue::glue_sql()`.
- - `"sqltargets.glue_sql_closing_delimiter"` - character. Length 1. Two characters. The closing delimiter passed to `glue::glue_sql()`.
+ - `"sqltargets.jinja_block_open"` - character. Length 1. The opening delimiter passed to `jinjar::jinjar_config()`.
+ - `"sqltargets.jinja_block_close"` - character. Length 1. The closing delimiter passed to `jinjar::jinjar_config()`.
+ - `"sqltargets.jinja_variable_open"` - character. Length 1. The closing delimiter passed to `jinjar::jinjar_config()`.
+ - `"sqltargets.jinja_variable_close"` - character. Length 1. The closing delimiter passed to `jinjar::jinjar_config()`.
+ - `"sqltargets.jinja_comment_open"` - character. Length 1. The closing delimiter passed to `jinjar::jinjar_config()`.
+ - `"sqltargets.jinja_comment_close"` - character. Length 1. The closing delimiter passed to `jinjar::jinjar_config()`.
 }

--- a/man/tar_sql.Rd
+++ b/man/tar_sql.Rd
@@ -7,7 +7,7 @@
 tar_sql(
   name,
   path,
-  query_params = list(),
+  params = list(),
   format = targets::tar_option_get("format"),
   tidy_eval = targets::tar_option_get("tidy_eval"),
   repository = targets::tar_option_get("repository"),
@@ -43,9 +43,9 @@ to locally recreate the target's initial RNG state.}
 \item{path}{Character of length 1 to the single `*.sql` source file to be executed.
 Defaults to the working directory of the `targets` pipeline.}
 
-\item{query_params}{Code, can be `NULL`.
-`query_params` evaluates to a named list of parameters
-that are passed via `glue::glue_sql()`. The list is quoted
+\item{params}{Code, can be `NULL`.
+`params` evaluates to a named list of parameters
+that are passed to `jinjar::render()`. The list is quoted
 (not evaluated until the target runs)
 so that upstream targets can serve as parameter values.}
 

--- a/man/tar_sql_raw.Rd
+++ b/man/tar_sql_raw.Rd
@@ -7,7 +7,7 @@
 tar_sql_raw(
   name,
   path = ".",
-  query_params = query_params,
+  params = params,
   format = format,
   error = targets::tar_option_get("error"),
   memory = targets::tar_option_get("memory"),
@@ -40,7 +40,11 @@ to locally recreate the target's initial RNG state.}
 \item{path}{Character of length 1 to the single `*.sql` source file to be executed.
 Defaults to the working directory of the `targets` pipeline.}
 
-\item{query_params}{A named list of parameters for parameterized queries.}
+\item{params}{Code, can be `NULL`.
+`params` evaluates to a named list of parameters
+that are passed to `jinjar::render()`. The list is quoted
+(not evaluated until the target runs)
+so that upstream targets can serve as parameter values.}
 
 \item{format}{Optional storage format for the target's return value.
 With the exception of \code{format = "file"}, each target

--- a/tests/testthat/test-tar-sql.R
+++ b/tests/testthat/test-tar-sql.R
@@ -64,10 +64,10 @@ targets::tar_test("tar_sql() for Jinja for loop", {
     "-- !preview conn=DBI::dbConnect(RSQLite::SQLite())",
     "-- tar_load(params)",
     "select",
-    "{% for payment_method in params.payment_methods -%}",
-    "0 as {{ payment_method }}_amount,",
-    "{% endfor -%}",
-    "1 as id",
+    "{% for payment_method in params.payment_methods %}",
+    "0 as {{ payment_method }}_amount",
+    "{% if not loop.is_last %},{% endif %}",
+    "{% endfor %}",
     ""
   )
   writeLines(lines, "query.sql")
@@ -86,6 +86,5 @@ targets::tar_test("tar_sql() for Jinja for loop", {
   out <- targets::tar_read(report)
   expect_equal(out, data.frame(bank_transfer_amount = 0,
                                credit_card_amount = 0,
-                               gift_card_amount = 0,
-                               id = 1))
+                               gift_card_amount = 0))
 })

--- a/tests/testthat/test-tar-sql.R
+++ b/tests/testthat/test-tar-sql.R
@@ -35,26 +35,57 @@ targets::tar_test("tar_sql() works", {
   expect_equal(sort(targets::tar_progress()$name), sort(c("data", "report", "query.sql")))
 })
 
-targets::tar_test("tar_sql() for parameterized queries", {
+targets::tar_test("tar_sql() for Jinja queries 1", {
   lines <- c(
     "-- !preview conn=DBI::dbConnect(RSQLite::SQLite())",
-    "-- tar_load(query_params)",
-    "select {val} as {col_name}",
+    "-- tar_load(params)",
+    "select {{ params.val }} as {{ params.col_name }}",
     ""
   )
   writeLines(lines, "query.sql")
   targets::tar_script({
     library(sqltargets)
     list(
-      targets::tar_target(query_params, list(val = 3, col_name = "column1")),
+      targets::tar_target(params, list(val = 3, col_name = "column1")),
       tar_sql(
         report,
         path = "query.sql",
-        query_params = query_params
+        params = params
       )
     )
   })
   suppressMessages(targets::tar_make(callr_function = NULL))
   out <- targets::tar_read(report)
   expect_equal(out, data.frame(column1 = 3))
+})
+
+targets::tar_test("tar_sql() for Jinja for loop", {
+  lines <- c(
+    "-- !preview conn=DBI::dbConnect(RSQLite::SQLite())",
+    "-- tar_load(params)",
+    "select",
+    "{% for payment_method in params.payment_methods -%}",
+    "0 as {{ payment_method }}_amount,",
+    "{% endfor -%}",
+    "1 as id",
+    ""
+  )
+  writeLines(lines, "query.sql")
+  targets::tar_script({
+    library(sqltargets)
+    list(
+      targets::tar_target(params, list(payment_methods = c("bank_transfer", "credit_card", "gift_card"))),
+      tar_sql(
+        report,
+        path = "query.sql",
+        params = params
+      )
+    )
+  })
+  suppressMessages(targets::tar_make(callr_function = NULL))
+  out <- targets::tar_read(report)
+  expect_equal(out, data.frame(bank_transfer_amount = 0,
+                               credit_card_amount = 0,
+                               gift_card_amount = 0,
+                               id = 1))
 })

--- a/tests/testthat/test-tar-sqltargets-options.R
+++ b/tests/testthat/test-tar-sqltargets-options.R
@@ -1,29 +1,29 @@
 test_that("sqltargets_option_set() works", {
   sqltargets_option_set("sqltargets.target_file_suffix", "_x_query")
-  sqltargets_option_set("sqltargets.glue_sql_opening_delimiter", "<<")
-  sqltargets_option_set("sqltargets.glue_sql_closing_delimiter", ">>")
+  sqltargets_option_set("sqltargets.jinja_block_open", "<<")
+  sqltargets_option_set("sqltargets.jinja_block_close", ">>")
   expect_equal(sqltargets_option_get("sqltargets.target_file_suffix"), "_x_query")
-  expect_equal(sqltargets_option_get("sqltargets.glue_sql_opening_delimiter"), "<<")
-  expect_equal(sqltargets_option_get("sqltargets.glue_sql_closing_delimiter"), ">>")
+  expect_equal(sqltargets_option_get("sqltargets.jinja_block_open"), "<<")
+  expect_equal(sqltargets_option_get("sqltargets.jinja_block_close"), ">>")
 })
 
 targets::tar_test("different delimiters work", {
   lines <- c(
     "-- !preview conn=DBI::dbConnect(RSQLite::SQLite())",
-    "-- tar_load(query_params)",
-    "select @val@ as @col_name@",
+    "-- tar_load(params)",
+    "select [[params.val]] as [[params.col_name]]",
     ""
   )
   writeLines(lines, "query.sql")
   targets::tar_script({
-    sqltargets_option_set("sqltargets.glue_sql_opening_delimiter", "@")
-    sqltargets_option_set("sqltargets.glue_sql_closing_delimiter", "@")
+    sqltargets_option_set("sqltargets.jinja_variable_open", "[[")
+    sqltargets_option_set("sqltargets.jinja_variable_close", "]]")
     list(
-      targets::tar_target(query_params, list(val = 3, col_name = "column1")),
+      targets::tar_target(params, list(val = 3, col_name = "column1")),
       tar_sql(
         report,
         path = "query.sql",
-        query_params = query_params
+        params = params
       )
     )
   }, ask = FALSE)


### PR DESCRIPTION
This PR will allow users to write 'jinja' within SQL queries by adding the ['jinjar' package](https://github.com/davidchall/jinjar) as a dependency. 

Closes #14 

# Changes
There is a breaking change by truncating the argument `query_params` to `params` (to better align with `quarto::quarto_render()`. 

# Checklist

- [x] jinjar import
- [x] tests
- [x] update NEWS.md
- [x] devtools::check() passes locally