### PR TITLE
Prefer `glue_data_sql()` when data is list-ish, not an actual environment

### DIFF
--- a/R/source_sql_to_dataframe.R
+++ b/R/source_sql_to_dataframe.R
@@ -20,13 +20,13 @@ source_sql_to_dataframe <- function(path, params = NULL) {
       )
     )
   } else {
-    query <- glue::glue_sql(
+    query <- glue::glue_data_sql(
+      params,
       query,
       .con = con,
       .open = sqltargets_option_get("sqltargets.glue_sql_opening_delimiter"),
-      .close = sqltargets_option_get("sqltargets.glue_sql_closing_delimiter"),
-      .envir = params
-      )
+      .close = sqltargets_option_get("sqltargets.glue_sql_closing_delimiter")
+    )
   }
   out <- DBI::dbGetQuery(con, query)
   msg <- glue::glue("{basename(path)} executed:\n Rows: {nrow(out)}\n Columns: {ncol(out)}")


### PR DESCRIPTION
This PR is inspired by doing revdep checks for glue. In the next release of glue, which is _very soon_, `glue::glue()` will error when `.envir` is not an actual environment. `.envir` has always been documented to be an environment and I've been working to make this actually true. And ditto for `glue::glue_sql()`, which is what affects sqltargets.

I last did revdep checks for this in December 2023 and I opened issue or PRs everywhere that I could. So sqltargets's usage of this pattern must have arisen more recently (?).

`glue_data_sql()` *does* officially accept something "list-ish" as `.x`. So you should switch to `glue_data_sql(.x = list_ish_thing, ...)` as opposed to `glue_sql(.envir = list_ish_thing, ...)`.

Relevant links in glue:

https://github.com/tidyverse/glue/issues/308
https://github.com/tidyverse/glue/commit/e2b74ff17704261b5a7da25b4ebd2dec94740764
https://github.com/tidyverse/glue/issues/341

Here's what I'm currently seeing for sqltargets in glue's revdep checks:
https://github.com/tidyverse/glue/blob/main/revdep/problems.md#sqltargets