### PR TITLE
Include tar_read support as well as tar_load when parsing deps in sql files

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -30,7 +30,7 @@ sql_deps <- function(path) {
 sql_expr <- function(path) {
   tryCatch( {
     text <- sql_lines(path)
-    text <- text[grepl("tar_load", text)]
+    text <- text[grepl("tar_(load|read)", text)]
     parse(text = text)
   },
     error = function(e) {

--- a/tests/testthat/test-tar-sql-deps.R
+++ b/tests/testthat/test-tar-sql-deps.R
@@ -3,6 +3,7 @@ targets::tar_test("tar_sql_deps() works", {
     "-- !preview conn=DBI::dbConnect(RSQLite::SQLite())",
     "-- tar_load(data1)",
     "-- tar_load(data2)",
+    "-- tar_read(data3)",
     "select 1 as my_col",
     ""
   )
@@ -17,5 +18,5 @@ targets::tar_test("tar_sql_deps() works", {
   })
   suppressMessages(targets::tar_make(callr_function = NULL))
   out <- tar_sql_deps("query.sql")
-  expect_equal(out, c("data1", "data2"))
+  expect_equal(out, c("data1", "data2", "data3"))
 })


### PR DESCRIPTION
`tar_sql` [documentation](https://github.com/daranzolin/sqltargets/blob/3d75aaadefc901e6d24c5236b1aef9e3f9901c04/R/tar_sql.R#L13) suggests this was the original intent and is congruent with `walk_call_sql`, and `walk_call_knitr` in tarchetypes.