### PR TITLE
Better handle queries that do not require parameters

### DIFF
--- a/R/source_sql_to_dataframe.R
+++ b/R/source_sql_to_dataframe.R
@@ -33,7 +33,8 @@ source_sql_to_dataframe <- function(path, params = NULL) {
     out <- DBI::dbGetQuery(con, query)
   } else if (template_engine == "dbi") {
     sth <- DBI::dbSendQuery(con, query)
-    DBI::dbBind(sth, params)
+    # Avoid Query does not require parameters.
+    if(!rlang::is_empty(params)) { DBI::dbBind(sth, params) }
     out <- DBI::dbFetch(sth, n = -1)
     DBI::dbClearResult(sth)
   } else {


### PR DESCRIPTION
Added missing test and code to check when `params` is empty and no parameters are in the SQL `select count * from table`.